### PR TITLE
Implement tool trusted modifier client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.13.0
           args: --timeout=5m
 
   mod-tidy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24.11"]
+        go-version: ["1.25.13"]
 
     steps:
       - name: Checkout code
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.25.13"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.25.13"
 
       - name: Check go mod tidy
         run: |
@@ -102,7 +102,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.25.13"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.25.13"
 
       - name: Check formatting
         run: |
@@ -142,7 +142,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.25.13"
 
       - name: Build examples
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.25.13"]
+        go-version: ["1.24.11"]
 
     steps:
       - name: Checkout code
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.13"
+          go-version: "1.24.11"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.13"
+          go-version: "1.24.11"
 
       - name: Check go mod tidy
         run: |
@@ -102,7 +102,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.13"
+          go-version: "1.24.11"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.13"
+          go-version: "1.24.11"
 
       - name: Check formatting
         run: |
@@ -142,7 +142,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.13"
+          go-version: "1.24.11"
 
       - name: Build examples
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.25.13"
 
       - name: Cache Go modules
         uses: actions/cache@v4
@@ -30,9 +30,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.24-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.25-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.24-
+            ${{ runner.os }}-go-1.25-
 
       - name: Download dependencies
         run: go mod download
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.25.13"
 
       - name: Test go get
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.13"
+          go-version: "1.24.11"
 
       - name: Cache Go modules
         uses: actions/cache@v4
@@ -30,9 +30,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.25-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.24-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.25-
+            ${{ runner.os }}-go-1.24-
 
       - name: Download dependencies
         run: go mod download
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.13"
+          go-version: "1.24.11"
 
       - name: Test go get
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # This file is licensed under the terms of the MIT license https://opensource.org/license/mit
 # Copyright (c) 2021-2025 Marat Reymers
 
-## Golden config for golangci-lint v2.2.2
+## Golden config for golangci-lint v2.13.0
 #
 # This is the best config for golangci-lint based on my experience and opinion.
 # It is very strict, but not extremely strict.
@@ -450,3 +450,6 @@ linters:
           - gosec
           - noctx
           - wrapcheck
+      - path: '^example/main\.go$'
+        linters:
+          - goconst

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang        1.25.13
+golang        1.24.11
 golangci-lint 2.13.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang        1.24.11
+golang        1.25.13
 golangci-lint 2.7.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang        1.24.11
+golang        1.25.13
 golangci-lint 2.13.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 golang        1.25.13
-golangci-lint 2.7.2
+golangci-lint 2.13.0

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The client library is organized into the following packages:
 - `neural.go` - Neural service wrapper that uses the neural package
 - `sensory.go` - Sensory service wrapper that uses the sensory package
 - `perception.go` - Perception service wrapper that uses the perception package
+- `tools.go` - Tools service wrapper that uses the tools package
 - `types.go` - Shared types and documentation
 
 ### Neural Package (`neural/`)
@@ -179,6 +180,14 @@ The client library is organized into the following packages:
 - `path.go` - Path operations (GET, POST, PATCH, PUT, DELETE)
 - `context.go` - Context operations (GET, POST, PATCH, PUT, DELETE)
 
+### Tools Package (`tools/`)
+- `service.go` - Service definition and typed API error handling
+- `input.go` - Thought-tool input operations
+- `initializer.go` - Thought-tool initializer operations
+- `output.go` - Thought-tool output operations
+- `option.go` - Output option operations
+- `modifier.go` - Trusted thought-tool modifier operations (GET, POST, PATCH, PUT, DELETE)
+
 ### Examples
 - `example/` - Working examples demonstrating all features
 
@@ -193,6 +202,7 @@ Detailed API documentation is available in the [`docs/`](docs/) directory:
 - **[Memory Service](docs/memory.md)** - Prompt operations and memory management
 - **[Sensory Service](docs/sensory.md)** - Source, Model, Limit, Specification, and Identity operations
 - **[Perception Service](docs/perception.md)** - Chain, Thought, Path, and Context operations
+- **[Tools Service](docs/tools.md)** - Input, initializer, output, option, and trusted modifier operations
 
 For a complete overview, see the [documentation index](docs/README.md).
 
@@ -296,6 +306,17 @@ Note: Paths are associated with thoughts and define target classes with configur
 - `DELETE /provision/perception/contexts/:id` - Delete context
 
 Note: Contexts are associated with thoughts and contain prompt IDs with layer information for neural processing operations.
+
+### Tools Resources (`/provision/tools`)
+
+#### Trusted thought-tool modifiers
+- `GET /provision/tools/modifiers/:id` - Get an active modifier by ID
+- `POST /provision/tools/:thought_tool_id/modifiers` - Create or reactivate a modifier
+- `PATCH /provision/tools/modifiers/:id` - Update a modifier
+- `PUT /provision/tools/modifiers/:id` - Send mutable replacement fields
+- `DELETE /provision/tools/modifiers/:id` - Deactivate a modifier
+
+Trusted tool modifiers reserve request fields for values resolved from authoritative runtime metadata. The API does not expose a list endpoint for this resource; PUT routes to the same update action as PATCH and cannot change the immutable index.
 
 ## Usage Examples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This directory contains the API documentation for the Tama Go client library, or
 - [Motor Service](motor.md) - Action operations
 - [Perception Service](perception.md) - Chain, Thought, Path, and Context operations
 - [Contexts Service](contexts.md) - Input operations
+- [Tools Service](tools.md) - Thought-tool inputs, initializers, outputs, options, and trusted modifiers
 
 ## Quick Start
 
@@ -58,5 +59,6 @@ func main() {
 - **Motor Service**: Handles action operations
 - **Perception Service**: Handles chains, thoughts, paths, and contexts
 - **Contexts Service**: Handles input operations
+- **Tools Service**: Manages thought-tool inputs, initializers, outputs, options, and trusted modifiers
 
 Each service provides comprehensive CRUD operations with proper error handling and validation.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,475 +1,234 @@
 # Tools Service
 
-The **Tools** service provides three main categories of operations:
-- **Input** – Manage tool inputs (type, class corpus ID, CRUD).
-- **Initializer** – Manage tool initializers (reference, index, parameters, CRUD).
-- **Output** – Manage tool outputs (class corpus ID, CRUD).
-- **Option** – Manage tool options (maps outputs to action modifiers, CRUD).
-
-These are exposed via the `Client.Tools` field and can be accessed as follows:
+The Tools service provisions inputs, initializers, outputs, output options, and
+trusted thought-tool modifiers. Its methods are exposed directly through
+`Client.Tools`:
 
 ```go
 client := tama.NewClient(config)
-tools := client.Tools
 
-// Input operations
-input, err := tools.Input.Create(ctx, newInput)
-
-// Initializer operations
-initializer, err := tools.Initializer.Create(ctx, newInitializer)
+input, err := client.Tools.GetInput("input-123")
+modifier, err := client.Tools.GetModifier("modifier-123")
 ```
 
-## Table of Contents
+Methods do not take a `context.Context`; request timeouts are configured on the
+root `tama.Client`.
 
-- [Overview](#overview)
-- [Input Operations](#input-operations)
-  - [Create](#create-input)
-  - [Get](#get-input)
-  - [List](#list-inputs)
-  - [Update](#update-input)
-  - [Delete](#delete-input)
-- [Initializer Operations](#initializer-operations)
-  - [Create](#create-initializer)
-  - [Get](#get-initializer)
-  - [List](#list-initializers)
-  - [Update](#update-initializer)
-  - [Delete](#delete-initializer)
-- [Output Operations](#output-operations)
-- [Option Operations](#option-operations)
+## Supported operations
 
-## Overview
+| Resource | Get | Create parent | Update | Replace | Delete |
+| --- | --- | --- | --- | --- | --- |
+| Input | `GetInput` | `CreateInput(thoughtToolID, ...)` | `UpdateInput` | `ReplaceInput` | `DeleteInput` |
+| Initializer | `GetInitializer` | `CreateInitializer(thoughtToolID, ...)` | `UpdateInitializer` | `ReplaceInitializer` | `DeleteInitializer` |
+| Output | `GetOutput` | `CreateOutput(thoughtToolID, ...)` | `UpdateOutput` | `ReplaceOutput` | `DeleteOutput` |
+| Option | `GetOption` | `CreateOption(outputID, ...)` | `UpdateOption` | `ReplaceOption` | `DeleteOption` |
+| Modifier | `GetModifier` | `CreateModifier(thoughtToolID, ...)` | `UpdateModifier` | `ReplaceModifier` | `DeleteModifier` |
 
-The Tools service allows clients to store and retrieve metadata about tools that can be used by other services such as **Perception**.  
-- An **Input** represents a set of parameters that a tool expects.
-- An **Initializer** contains the logic (reference, index, parameters) required to instantiate or invoke a tool.
+The Tama provision API does not currently expose Tools list endpoints. Phoenix
+routes both `PATCH` and `PUT` to each resource's update action. Consequently,
+the `Replace*` methods use the same request fields as `Update*`; callers should
+not assume that PUT can change server-owned or immutable fields.
 
-Both resources support full CRUD operations with pagination for listing endpoints.
+## Inputs
 
-## Input Operations
-
-### Create
-```go
-func (s *InputService) Create(ctx context.Context, input *tools.Input) (*tools.Input, error)
-```
-Creates a new tool input. Required fields: `Type`, `ClassCorpusID`.
-
-### Get
-```go
-func (s *InputService) Get(ctx context.Context, id string) (*tools.Input, error)
-```
-Retrieves an existing input by its unique identifier.
-
-### List
-```go
-func (s *InputService) List(ctx context.Context, opts *tools.ListOptions) ([]*tools.Input, error)
-```
-Returns a paginated list of inputs. Supports filtering by `Type` or `ClassCorpusID`.
-
-### Update
-```go
-func (s *InputService) Update(ctx context.Context, id string, input *tools.InputUpdate) (*tools.Input, error)
-```
-Updates mutable fields of an existing input.
-
-### Delete
-```go
-func (s *InputService) Delete(ctx context.Context, id string) error
-```
-Deletes the specified input.
-
-## Initializer Operations
-
-### Create
-```go
-func (s *InitializerService) Create(ctx context.Context, init *tools.Initializer) (*tools.Initializer, error)
-```
-Creates a new tool initializer. Required fields: `Reference`, `Index`, `Parameters`.
-
-### Get
-```go
-func (s *InitializerService) Get(ctx context.Context, id string) (*tools.Initializer, error)
-```
-Retrieves an existing initializer by its unique identifier.
-
-### List
-```go
-func (s *InitializerService) List(ctx context.Context, opts *tools.ListOptions) ([]*tools.Initializer, error)
-```
-Returns a paginated list of initializers. Supports filtering by `Reference`.
-
-### Update
-```go
-func (s *InitializerService) Update(ctx context.Context, id string, init *tools.InitializerUpdate) (*tools.Initializer, error)
-```
-Updates mutable fields of an existing initializer.
-
-### Delete
-```go
-func (s *InitializerService) Delete(ctx context.Context, id string) error
-```
-Deletes the specified initializer.
-
-## Usage Example
+An input associates a thought tool with a class corpus and input type.
 
 ```go
-import (
-    "context"
-    "github.com/upmaru/tama-go"
-)
-
-func main() {
-    cfg := tama.Config{BaseURL: "https://api.tama.io", APIKey: "YOUR_KEY"}
-    client := tama.NewClient(cfg)
-    ctx := context.Background()
-
-    // Create an input
-    in, _ := client.Tools.Input.Create(ctx, &tama.tools.Input{
+created, err := client.Tools.CreateInput("tool-123", tools.CreateInputRequest{
+    Input: tools.InputRequestData{
         Type:          "text",
-        ClassCorpusID: "corpus-123",
-    })
-
-    // Create an initializer referencing the input
-    init, _ := client.Tools.Initializer.Create(ctx, &tama.tools.Initializer{
-        Reference:  in.ID,
-        Index:      0,
-        Parameters: []string{"param1", "param2"},
-    })
-}
-```
-
-> **Tip:**  
-> Use the listing endpoints with pagination options (`Limit`, `Offset`) to efficiently navigate large sets of inputs or initializers.
-
---- 
-
-For more detailed information on each service, refer to the generated SDK documentation in the `tools` package source.
-
-## Output Operations
-
-### GetOutput(id string) (*Output, error)
-
-Retrieves a specific tools output by ID.
-
-**Endpoint:** `GET /provision/tools/outputs/:id`
-
-**Parameters:**
-- `id` (string): Output ID (required)
-
-**Returns:**
-- `*Output`: Output object with ID, ThoughtToolID, ClassCorpusID, and ProvisionState
-- `error`: Error if request fails
-
-**Example:**
-```go
-output, err := client.Tools.GetOutput("output-123")
-if err != nil {
-    log.Fatal(err)
-}
-fmt.Printf("Output: %+v\n", output)
-```
-
-### CreateOutput(thoughtToolID string, req CreateOutputRequest) (*Output, error)
-
-Creates a new output under a specific thought tool.
-
-**Endpoint:** `POST /provision/tools/:thought_tool_id/outputs`
-
-**Parameters:**
-- `thoughtToolID` (string): Parent thought tool ID (required)
-- `req` (CreateOutputRequest): Output creation request (required)
-  - `Output` (OutputRequestData): Output data (required)
-    - `ClassCorpusID` (string): Class corpus ID (required)
-
-**Returns:**
-- `*Output`: Created output object
-- `error`: Error if request fails
-
-**Request Structure:**
-```go
-type CreateOutputRequest struct {
-    Output OutputRequestData `json:"output"`
-}
-
-type OutputRequestData struct {
-    ClassCorpusID string `json:"class_corpus_id"`
-}
-```
-
-**Example:**
-```go
-req := tools.CreateOutputRequest{
-    Output: tools.OutputRequestData{
         ClassCorpusID: "corpus-789",
     },
-}
-created, err := client.Tools.CreateOutput("tool-123", req)
+})
+
+updated, err := client.Tools.UpdateInput(created.ID, tools.UpdateInputRequest{
+    Input: tools.UpdateInputData{Type: "json"},
+})
 ```
 
-### UpdateOutput(id string, req UpdateOutputRequest) (*Output, error)
+## Initializers
 
-Updates an existing output using PATCH (partial update).
+An initializer supplies a reference, optional index, and arbitrary parameters
+used to initialize a thought tool.
 
-**Endpoint:** `PATCH /provision/tools/outputs/:id`
-
-**Parameters:**
-- `id` (string): Output ID (required)
-- `req` (UpdateOutputRequest): Output update request (required)
-  - `Output` (UpdateOutputData): Updatable fields
-    - `ClassCorpusID` (string, optional)
-
-**Returns:**
-- `*Output`: Updated output object
-- `error`: Error if request fails
-
-**Request Structure:**
 ```go
-type UpdateOutputRequest struct {
-    Output UpdateOutputData `json:"output"`
-}
-
-type UpdateOutputData struct {
-    ClassCorpusID string `json:"class_corpus_id,omitempty"`
-}
-```
-
-**Example:**
-```go
-update := tools.UpdateOutputRequest{
-    Output: tools.UpdateOutputData{
-        ClassCorpusID: "corpus-updated",
+index := 0
+created, err := client.Tools.CreateInitializer("tool-123", tools.CreateInitializerRequest{
+    Initializer: tools.InitializerRequestData{
+        Reference:  "tama/example/initializer",
+        Index:      &index,
+        Parameters: map[string]any{"temperature": 0.2},
     },
-}
-updated, err := client.Tools.UpdateOutput("output-123", update)
+})
 ```
 
-### ReplaceOutput(id string, req UpdateOutputRequest) (*Output, error)
+## Outputs and options
 
-Replaces an existing output using PUT (full replacement semantics on the server side).
+An output associates a thought tool with a class corpus. An option associates
+that output with a Motor action modifier.
 
-**Endpoint:** `PUT /provision/tools/outputs/:id`
-
-**Parameters:**
-- `id` (string): Output ID (required)
-- `req` (UpdateOutputRequest): Replacement request (required)
-
-**Returns:**
-- `*Output`: Replaced output object
-- `error`: Error if request fails
-
-**Example:**
 ```go
-replace := tools.UpdateOutputRequest{
-    Output: tools.UpdateOutputData{
-        ClassCorpusID: "corpus-replaced",
+output, err := client.Tools.CreateOutput("tool-123", tools.CreateOutputRequest{
+    Output: tools.OutputRequestData{ClassCorpusID: "corpus-789"},
+})
+
+option, err := client.Tools.CreateOption(output.ID, tools.CreateOptionRequest{
+    Option: tools.OptionRequestData{ActionModifierID: "action-modifier-123"},
+})
+```
+
+`tools.Option` and `tools.Modifier` are different resources. An option refers to
+an action-level `motor.Modifier`; a trusted tool modifier populates request
+arguments from runtime metadata.
+
+## Trusted tool modifiers
+
+A trusted tool modifier reserves a request field for a value obtained from
+authoritative runtime metadata instead of model-generated arguments.
+
+### Types and constants
+
+```go
+type ModifierSource struct {
+    Type string `json:"type"`
+    Path string `json:"path"`
+}
+
+type Modifier struct {
+    ID              string
+    Index           int
+    Target          string
+    OnMissingParent string
+    OnMissingSource string
+    Source          ModifierSource
+    ThoughtToolID   string
+    ProvisionState  string
+}
+```
+
+Use the exported wire-value constants:
+
+```go
+tools.ModifierMissingPolicyError
+tools.ModifierMissingPolicySkip
+tools.ModifierSourceTypeMetadata
+tools.ModifierSourcePathActorIdentifier
+tools.ModifierSourcePathOriginEntityIdentifier
+tools.ModifierSourcePathCurrentTimestamp
+```
+
+### Create or reactivate
+
+```go
+modifier, err := client.Tools.CreateModifier("tool-123", tools.CreateModifierRequest{
+    Modifier: tools.ModifierRequestData{
+        Index:           0,
+        Target:          "/body/search/scope/user_id",
+        OnMissingParent: tools.ModifierMissingPolicySkip,
+        OnMissingSource: tools.ModifierMissingPolicyError,
+        Source: tools.ModifierSource{
+            Type: tools.ModifierSourceTypeMetadata,
+            Path: tools.ModifierSourcePathActorIdentifier,
+        },
     },
-}
-replaced, err := client.Tools.ReplaceOutput("output-123", replace)
+})
 ```
 
-### DeleteOutput(id string) error
+Create sends `POST /provision/tools/:thought_tool_id/modifiers`. Tama activates a
+new modifier and returns `201`. If the exact configuration already exists in an
+inactive state, Tama reactivates it and returns the same ID.
 
-Deletes an output by ID.
+All create fields are required. The client rejects empty structural fields and
+negative indexes before sending a request. Tama remains authoritative for
+allowed values, JSON Pointer syntax, callable-schema compatibility, and active
+modifier conflicts.
 
-**Endpoint:** `DELETE /provision/tools/outputs/:id`
+### Get
 
-**Parameters:**
-- `id` (string): Output ID (required)
-
-**Returns:**
-- `error`: Error if request fails
-
-**Example:**
 ```go
-if err := client.Tools.DeleteOutput("output-123"); err != nil {
-    log.Fatal(err)
-}
+modifier, err := client.Tools.GetModifier("modifier-123")
 ```
 
-## Output Structure
+Get sends `GET /provision/tools/modifiers/:id`. Only active modifiers are
+visible; invalid, unknown, and inactive IDs return `404`.
 
-### Output
-
-The `Output` struct represents a tools output with the following fields:
-
-```go
-type Output struct {
-    ID             string `json:"id,omitempty"`
-    ThoughtToolID  string `json:"thought_tool_id,omitempty"`
-    ClassCorpusID  string `json:"class_corpus_id"`
-    ProvisionState string `json:"provision_state"`
-}
-```
-
-### OutputResponse
-
-Wraps an Output in API responses:
+### Update
 
 ```go
-type OutputResponse struct {
-    Data Output `json:"data"`
-}
-```
-
-## Option Operations
-
-The Option resource binds a Thought Tool Output to a Motor Action Modifier. This allows you to specify which action should be taken when a particular tool output is selected.
-
-### GetOption(id string) (*Option, error)
-
-Retrieves a specific tools option by ID.
-
-**Endpoint:** `GET /provision/tools/options/:id`
-
-**Parameters:**
-- `id` (string): Option ID (required)
-
-**Returns:**
-- `*Option`: Option object with ID, ThoughtToolOutputID, ActionModifierID, and ProvisionState
-- `error`: Error if request fails
-
-**Example:**
-```go
-option, err := client.Tools.GetOption("option-123")
-```
-
-### CreateOption(outputID string, req CreateOptionRequest) (*Option, error)
-
-Creates a new option under a specific thought tool output.
-
-**Endpoint:** `POST /provision/tools/outputs/:output_id/options`
-
-**Parameters:**
-- `outputID` (string): Parent thought tool output ID (required)
-- `req` (CreateOptionRequest): Option creation request (required)
-  - `Option` (OptionRequestData): Option data (required)
-    - `ActionModifierID` (string): Action modifier ID (required)
-
-**Returns:**
-- `*Option`: Created option object
-- `error`: Error if request fails
-
-**Request Structure:**
-```go
-type CreateOptionRequest struct {
-    Option OptionRequestData `json:"option"`
+source := tools.ModifierSource{
+    Type: tools.ModifierSourceTypeMetadata,
+    Path: tools.ModifierSourcePathOriginEntityIdentifier,
 }
 
-type OptionRequestData struct {
-    ActionModifierID string `json:"action_modifier_id"`
-}
-```
-
-**Example:**
-```go
-req := tools.CreateOptionRequest{
-    Option: tools.OptionRequestData{
-        ActionModifierID: "modifier-789",
+modifier, err := client.Tools.UpdateModifier("modifier-123", tools.UpdateModifierRequest{
+    Modifier: tools.UpdateModifierData{
+        OnMissingParent: tools.ModifierMissingPolicyError,
+        Source:          &source,
     },
-}
-created, err := client.Tools.CreateOption("output-123", req)
+})
 ```
 
-### UpdateOption(id string, req UpdateOptionRequest) (*Option, error)
+Update sends `PATCH /provision/tools/modifiers/:id` and supports partial
+updates. `Source` is a pointer so it can be omitted; when supplied, both its
+`Type` and `Path` are required. `Index` is not part of the update type because
+Tama makes it immutable.
 
-Updates an existing option using PATCH (partial update).
+### Replace
 
-**Endpoint:** `PATCH /provision/tools/options/:id`
-
-**Parameters:**
-- `id` (string): Option ID (required)
-- `req` (UpdateOptionRequest): Option update request (required)
-  - `Option` (UpdateOptionData): Updatable fields
-    - `ActionModifierID` (string, optional)
-
-**Returns:**
-- `*Option`: Updated option object
-- `error`: Error if request fails
-
-**Request Structure:**
 ```go
-type UpdateOptionRequest struct {
-    Option UpdateOptionData `json:"option"`
-}
-
-type UpdateOptionData struct {
-    ActionModifierID string `json:"action_modifier_id,omitempty"`
-}
-```
-
-**Example:**
-```go
-update := tools.UpdateOptionRequest{
-    Option: tools.UpdateOptionData{
-        ActionModifierID: "modifier-updated",
+modifier, err := client.Tools.ReplaceModifier("modifier-123", tools.UpdateModifierRequest{
+    Modifier: tools.UpdateModifierData{
+        Target:          "/body/search/scope/account_id",
+        OnMissingParent: tools.ModifierMissingPolicyError,
+        OnMissingSource: tools.ModifierMissingPolicyError,
+        Source:          &source,
     },
-}
-updated, err := client.Tools.UpdateOption("option-123", update)
+})
 ```
 
-### ReplaceOption(id string, req UpdateOptionRequest) (*Option, error)
+Replace sends `PUT /provision/tools/modifiers/:id`. Tama routes PUT to the same
+update action as PATCH, so the mutable request type is shared and `index`
+remains unavailable.
 
-Replaces an existing option using PUT (full replacement semantics on the server side).
-
-**Endpoint:** `PUT /provision/tools/options/:id`
-
-**Parameters:**
-- `id` (string): Option ID (required)
-- `req` (UpdateOptionRequest): Replacement request (required)
-
-**Returns:**
-- `*Option`: Replaced option object
-- `error`: Error if request fails
-
-**Example:**
-```go
-replace := tools.UpdateOptionRequest{
-    Option: tools.UpdateOptionData{
-        ActionModifierID: "modifier-replaced",
-    },
-}
-replaced, err := client.Tools.ReplaceOption("option-123", replace)
-```
-
-### DeleteOption(id string) error
-
-Deletes an option by ID.
-
-**Endpoint:** `DELETE /provision/tools/options/:id`
-
-**Parameters:**
-- `id` (string): Option ID (required)
-
-**Returns:**
-- `error`: Error if request fails
-
-**Example:**
-```go
-if err := client.Tools.DeleteOption("option-123"); err != nil {
-    log.Fatal(err)
-}
-```
-
-## Option Structure
-
-### Option
-
-Represents a tool option and its binding to an action modifier:
+### Delete
 
 ```go
-type Option struct {
-    ID                  string `json:"id,omitempty"`
-    ThoughtToolOutputID string `json:"thought_tool_output_id,omitempty"`
-    ActionModifierID    string `json:"action_modifier_id"`
-    ProvisionState      string `json:"provision_state"`
-}
+err := client.Tools.DeleteModifier("modifier-123")
 ```
 
-### OptionResponse
+Delete sends `DELETE /provision/tools/modifiers/:id`. Tama deactivates the
+resource and returns it with `provision_state` set to `inactive`; the client
+discards that response body.
 
-Wraps an Option in API responses:
+## Errors
+
+Parsed API failures are returned as `*tools.Error`. This permits callers to
+distinguish refresh-time not-found responses and inspect flattened validation
+fields:
 
 ```go
-type OptionResponse struct {
-    Data Option `json:"data"`
+var apiErr *tools.Error
+if errors.As(err, &apiErr) {
+    if apiErr.StatusCode == http.StatusNotFound {
+        // The active resource no longer exists.
+    }
+
+    sourcePathMessages := apiErr.Errors["source.path"]
 }
 ```
+
+Local structural validation errors are ordinary Go errors. Server responses,
+including `404`, `401`, and `422`, retain their HTTP status through
+`tools.Error.StatusCode`.
+
+## Modifier authorization
+
+A credential needs both narrow capabilities for a complete lifecycle:
+
+```text
+provision.tools.modifier.read
+provision.tools.modifier.manage
+```
+
+`read` authorizes get. `manage` authorizes create, update/replace, and delete.
+Either `provision.tools.all` or `provision.all` grants all modifier operations.

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/upmaru/tama-go
 
-go 1.24
+go 1.25.0
 
 require github.com/go-resty/resty/v2 v2.17.1
 
-require golang.org/x/net v0.43.0 // indirect
+require golang.org/x/net v0.55.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/upmaru/tama-go
 
-go 1.25.0
+go 1.24
 
 require github.com/go-resty/resty/v2 v2.17.1
 
-require golang.org/x/net v0.55.0 // indirect
+require golang.org/x/net v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/go-resty/resty/v2 v2.17.1 h1:x3aMpHK1YM9e4va/TMDRlusDDoZiQ+ViDu/WpA6xTM4=
 github.com/go-resty/resty/v2 v2.17.1/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
-golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
-golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/go-resty/resty/v2 v2.17.1 h1:x3aMpHK1YM9e4va/TMDRlusDDoZiQ+ViDu/WpA6xTM4=
 github.com/go-resty/resty/v2 v2.17.1/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
+golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=

--- a/integration_test.go
+++ b/integration_test.go
@@ -401,7 +401,10 @@ func TestIntegrationFieldValidationErrors(t *testing.T) {
 	// Test duplicate space name (should pass client validation but fail server validation)
 	duplicateSpace := neural.CreateSpaceRequest{
 		Space: neural.SpaceRequestData{
-			Name: fmt.Sprintf("Field Validation Test Space %d", time.Now().Unix()), // Use same timestamp to potentially trigger slug conflict
+			Name: fmt.Sprintf(
+				"Field Validation Test Space %d",
+				time.Now().Unix(),
+			), // Use same timestamp to potentially trigger slug conflict
 			Type: "root",
 		},
 	}

--- a/perception/activation.go
+++ b/perception/activation.go
@@ -54,7 +54,15 @@ func (s *Service) CreateActivation(pathID string, req CreateActivationRequest) (
 	}
 
 	var activationResp ActivationResponse
-	if err := genericCreate(s, pathID, req, "activation", "path", "/provision/perception/paths/%s/activations", &activationResp); err != nil {
+	if err := genericCreate(
+		s,
+		pathID,
+		req,
+		"activation",
+		"path",
+		"/provision/perception/paths/%s/activations",
+		&activationResp,
+	); err != nil {
 		return nil, err
 	}
 	return &activationResp.Data, nil
@@ -64,7 +72,14 @@ func (s *Service) CreateActivation(pathID string, req CreateActivationRequest) (
 // PATCH /provision/perception/activations/:id.
 func (s *Service) UpdateActivation(id string, req UpdateActivationRequest) (*Activation, error) {
 	var activationResp ActivationResponse
-	if err := genericUpdate(s, id, req, "activation", "/provision/perception/activations/%s", &activationResp); err != nil {
+	if err := genericUpdate(
+		s,
+		id,
+		req,
+		"activation",
+		"/provision/perception/activations/%s",
+		&activationResp,
+	); err != nil {
 		return nil, err
 	}
 	return &activationResp.Data, nil
@@ -74,7 +89,14 @@ func (s *Service) UpdateActivation(id string, req UpdateActivationRequest) (*Act
 // PUT /provision/perception/activations/:id.
 func (s *Service) ReplaceActivation(id string, req UpdateActivationRequest) (*Activation, error) {
 	var activationResp ActivationResponse
-	if err := genericReplace(s, id, req, "activation", "/provision/perception/activations/%s", &activationResp); err != nil {
+	if err := genericReplace(
+		s,
+		id,
+		req,
+		"activation",
+		"/provision/perception/activations/%s",
+		&activationResp,
+	); err != nil {
 		return nil, err
 	}
 	return &activationResp.Data, nil

--- a/perception/directive.go
+++ b/perception/directive.go
@@ -59,7 +59,15 @@ func (s *Service) CreateDirective(pathID string, req CreateDirectiveRequest) (*D
 	}
 
 	var directiveResp DirectiveResponse
-	if err := genericCreate(s, pathID, req, "directive", "path", "/provision/perception/paths/%s/directives", &directiveResp); err != nil {
+	if err := genericCreate(
+		s,
+		pathID,
+		req,
+		"directive",
+		"path",
+		"/provision/perception/paths/%s/directives",
+		&directiveResp,
+	); err != nil {
 		return nil, err
 	}
 	return &directiveResp.Data, nil
@@ -69,7 +77,14 @@ func (s *Service) CreateDirective(pathID string, req CreateDirectiveRequest) (*D
 // PATCH /provision/perception/directives/:id.
 func (s *Service) UpdateDirective(id string, req UpdateDirectiveRequest) (*Directive, error) {
 	var directiveResp DirectiveResponse
-	if err := genericUpdate(s, id, req, "directive", "/provision/perception/directives/%s", &directiveResp); err != nil {
+	if err := genericUpdate(
+		s,
+		id,
+		req,
+		"directive",
+		"/provision/perception/directives/%s",
+		&directiveResp,
+	); err != nil {
 		return nil, err
 	}
 	return &directiveResp.Data, nil
@@ -79,7 +94,14 @@ func (s *Service) UpdateDirective(id string, req UpdateDirectiveRequest) (*Direc
 // PUT /provision/perception/directives/:id.
 func (s *Service) ReplaceDirective(id string, req UpdateDirectiveRequest) (*Directive, error) {
 	var directiveResp DirectiveResponse
-	if err := genericReplace(s, id, req, "directive", "/provision/perception/directives/%s", &directiveResp); err != nil {
+	if err := genericReplace(
+		s,
+		id,
+		req,
+		"directive",
+		"/provision/perception/directives/%s",
+		&directiveResp,
+	); err != nil {
 		return nil, err
 	}
 	return &directiveResp.Data, nil

--- a/perception/pruning.go
+++ b/perception/pruning.go
@@ -46,7 +46,15 @@ func (s *Service) GetPruning(id string) (*Pruning, error) {
 // POST /provision/perception/thoughts/:thought_id/prunings.
 func (s *Service) CreatePruning(thoughtID string, req CreatePruningRequest) (*Pruning, error) {
 	var pruningResp PruningResponse
-	if err := genericCreate(s, thoughtID, req, "pruning", "thought", "/provision/perception/thoughts/%s/prunings", &pruningResp); err != nil {
+	if err := genericCreate(
+		s,
+		thoughtID,
+		req,
+		"pruning",
+		"thought",
+		"/provision/perception/thoughts/%s/prunings",
+		&pruningResp,
+	); err != nil {
 		return nil, err
 	}
 	return &pruningResp.Data, nil

--- a/perception/thought_test.go
+++ b/perception/thought_test.go
@@ -1616,7 +1616,11 @@ func validateIndexRequest(t *testing.T, r *http.Request, expectedIndex *int, exp
 	if receivedRequest.Thought.Delegation == nil {
 		t.Error("Expected delegation to be present")
 	} else if receivedRequest.Thought.Delegation.TargetThoughtID != expectedTargetID {
-		t.Errorf("Expected target thought ID %s, got %s", expectedTargetID, receivedRequest.Thought.Delegation.TargetThoughtID)
+		t.Errorf(
+			"Expected target thought ID %s, got %s",
+			expectedTargetID,
+			receivedRequest.Thought.Delegation.TargetThoughtID,
+		)
 	}
 }
 

--- a/perception/tool.go
+++ b/perception/tool.go
@@ -54,7 +54,15 @@ func (s *Service) CreateTool(thoughtID string, req CreateToolRequest) (*Tool, er
 	}
 
 	var toolResp ToolResponse
-	if err := genericCreate(s, thoughtID, req, "tool", "thought", "/provision/perception/thoughts/%s/tools", &toolResp); err != nil {
+	if err := genericCreate(
+		s,
+		thoughtID,
+		req,
+		"tool",
+		"thought",
+		"/provision/perception/thoughts/%s/tools",
+		&toolResp,
+	); err != nil {
 		return nil, err
 	}
 	return &toolResp.Data, nil

--- a/tools.go
+++ b/tools.go
@@ -4,11 +4,14 @@ import (
 	"github.com/upmaru/tama-go/tools"
 )
 
-// ToolsService handles all tools-related API operations
+// ToolsService handles all tools-related API operations.
 //
 // The tools service operations are organized in a separate package:
 // - tools/input.go: Input operations (tools inputs with type, class corpus ID, and CRUD operations)
-// - tools/initializer.go: Initializer operations (tools initializers with reference, index, parameters, and CRUD operations).
+// - tools/initializer.go: Initializer operations (reference, index, parameters, and CRUD operations)
+// - tools/output.go: Output operations (class corpus ID and CRUD operations)
+// - tools/option.go: Output option operations (action modifier association and CRUD operations)
+// - tools/modifier.go: Trusted thought-tool modifier operations (runtime metadata projection and CRUD operations).
 type ToolsService struct {
 	*tools.Service
 }

--- a/tools/modifier.go
+++ b/tools/modifier.go
@@ -1,0 +1,237 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	// ModifierMissingPolicyError fails the tool call when the configured value is unavailable.
+	ModifierMissingPolicyError = "error"
+	// ModifierMissingPolicySkip leaves the request unchanged when the configured value is unavailable.
+	ModifierMissingPolicySkip = "skip"
+
+	// ModifierSourceTypeMetadata resolves modifier values from trusted runtime metadata.
+	ModifierSourceTypeMetadata = "metadata"
+
+	// ModifierSourcePathActorIdentifier resolves the current actor identifier.
+	ModifierSourcePathActorIdentifier = "actor_identifier"
+	// ModifierSourcePathOriginEntityIdentifier resolves the originating entity identifier.
+	ModifierSourcePathOriginEntityIdentifier = "origin_entity_identifier"
+	// ModifierSourcePathCurrentTimestamp resolves the current timestamp.
+	ModifierSourcePathCurrentTimestamp = "current_timestamp"
+)
+
+// ModifierSource identifies a trusted runtime value used by a tool modifier.
+type ModifierSource struct {
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
+
+// Modifier represents a trusted thought-tool modifier resource.
+type Modifier struct {
+	ID              string         `json:"id,omitempty"`
+	Index           int            `json:"index"`
+	Target          string         `json:"target"`
+	OnMissingParent string         `json:"on_missing_parent"`
+	OnMissingSource string         `json:"on_missing_source"`
+	Source          ModifierSource `json:"source"`
+	ThoughtToolID   string         `json:"thought_tool_id,omitempty"`
+	ProvisionState  string         `json:"provision_state"`
+}
+
+// ModifierResponse represents the API response for modifier operations.
+type ModifierResponse struct {
+	Data Modifier `json:"data"`
+}
+
+// CreateModifierRequest represents the request payload for creating a modifier.
+type CreateModifierRequest struct {
+	Modifier ModifierRequestData `json:"modifier"`
+}
+
+// ModifierRequestData represents the complete modifier data in a create request.
+type ModifierRequestData struct {
+	Index           int            `json:"index"`
+	Target          string         `json:"target"`
+	OnMissingParent string         `json:"on_missing_parent"`
+	OnMissingSource string         `json:"on_missing_source"`
+	Source          ModifierSource `json:"source"`
+}
+
+// UpdateModifierRequest represents the request payload for updating a modifier.
+type UpdateModifierRequest struct {
+	Modifier UpdateModifierData `json:"modifier"`
+}
+
+// UpdateModifierData represents the mutable fields in a modifier update.
+type UpdateModifierData struct {
+	Target          string          `json:"target,omitempty"`
+	OnMissingParent string          `json:"on_missing_parent,omitempty"`
+	OnMissingSource string          `json:"on_missing_source,omitempty"`
+	Source          *ModifierSource `json:"source,omitempty"`
+}
+
+// GetModifier retrieves a specific active modifier by ID.
+// GET /provision/tools/modifiers/:id.
+func (s *Service) GetModifier(id string) (*Modifier, error) {
+	if id == "" {
+		return nil, errors.New("modifier ID is required")
+	}
+
+	var modifierResp ModifierResponse
+	resp, err := s.client.R().
+		SetResult(&modifierResp).
+		Get(fmt.Sprintf("/provision/tools/modifiers/%s", id))
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get modifier: %w", err)
+	}
+
+	if apiErr := s.handleAPIError(resp); apiErr != nil {
+		return nil, apiErr
+	}
+
+	return &modifierResp.Data, nil
+}
+
+// CreateModifier creates or reactivates a modifier within a thought tool.
+// POST /provision/tools/:thought_tool_id/modifiers.
+func (s *Service) CreateModifier(
+	thoughtToolID string,
+	req CreateModifierRequest,
+) (*Modifier, error) {
+	if thoughtToolID == "" {
+		return nil, errors.New("thought tool ID is required")
+	}
+	if err := validateCreateModifier(req.Modifier); err != nil {
+		return nil, err
+	}
+
+	var modifierResp ModifierResponse
+	resp, err := s.client.R().
+		SetBody(req).
+		SetResult(&modifierResp).
+		Post(fmt.Sprintf("/provision/tools/%s/modifiers", thoughtToolID))
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create modifier: %w", err)
+	}
+
+	if apiErr := s.handleAPIError(resp); apiErr != nil {
+		return nil, apiErr
+	}
+
+	return &modifierResp.Data, nil
+}
+
+// UpdateModifier partially updates an active or inactive modifier using PATCH.
+// PATCH /provision/tools/modifiers/:id.
+func (s *Service) UpdateModifier(id string, req UpdateModifierRequest) (*Modifier, error) {
+	if id == "" {
+		return nil, errors.New("modifier ID is required")
+	}
+	if err := validateUpdateModifier(req.Modifier); err != nil {
+		return nil, err
+	}
+
+	var modifierResp ModifierResponse
+	resp, err := s.client.R().
+		SetBody(req).
+		SetResult(&modifierResp).
+		Patch(fmt.Sprintf("/provision/tools/modifiers/%s", id))
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to update modifier: %w", err)
+	}
+
+	if apiErr := s.handleAPIError(resp); apiErr != nil {
+		return nil, apiErr
+	}
+
+	return &modifierResp.Data, nil
+}
+
+// ReplaceModifier sends the mutable modifier fields using PUT.
+// PUT /provision/tools/modifiers/:id.
+func (s *Service) ReplaceModifier(id string, req UpdateModifierRequest) (*Modifier, error) {
+	if id == "" {
+		return nil, errors.New("modifier ID is required")
+	}
+	if err := validateUpdateModifier(req.Modifier); err != nil {
+		return nil, err
+	}
+
+	var modifierResp ModifierResponse
+	resp, err := s.client.R().
+		SetBody(req).
+		SetResult(&modifierResp).
+		Put(fmt.Sprintf("/provision/tools/modifiers/%s", id))
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to replace modifier: %w", err)
+	}
+
+	if apiErr := s.handleAPIError(resp); apiErr != nil {
+		return nil, apiErr
+	}
+
+	return &modifierResp.Data, nil
+}
+
+// DeleteModifier deactivates an active modifier by ID.
+// DELETE /provision/tools/modifiers/:id.
+func (s *Service) DeleteModifier(id string) error {
+	if id == "" {
+		return errors.New("modifier ID is required")
+	}
+
+	resp, err := s.client.R().
+		Delete(fmt.Sprintf("/provision/tools/modifiers/%s", id))
+
+	if err != nil {
+		return fmt.Errorf("failed to delete modifier: %w", err)
+	}
+
+	if apiErr := s.handleAPIError(resp); apiErr != nil {
+		return apiErr
+	}
+
+	return nil
+}
+
+func validateCreateModifier(modifier ModifierRequestData) error {
+	if modifier.Index < 0 {
+		return errors.New("modifier index must be non-negative")
+	}
+	if modifier.Target == "" {
+		return errors.New("modifier target is required")
+	}
+	if modifier.OnMissingParent == "" {
+		return errors.New("modifier on missing parent policy is required")
+	}
+	if modifier.OnMissingSource == "" {
+		return errors.New("modifier on missing source policy is required")
+	}
+
+	return validateModifierSource(modifier.Source)
+}
+
+func validateModifierSource(source ModifierSource) error {
+	if source.Type == "" {
+		return errors.New("modifier source type is required")
+	}
+	if source.Path == "" {
+		return errors.New("modifier source path is required")
+	}
+
+	return nil
+}
+
+func validateUpdateModifier(modifier UpdateModifierData) error {
+	if modifier.Source == nil {
+		return nil
+	}
+
+	return validateModifierSource(*modifier.Source)
+}

--- a/tools/modifier_test.go
+++ b/tools/modifier_test.go
@@ -1,0 +1,581 @@
+package tools_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tama "github.com/upmaru/tama-go"
+	"github.com/upmaru/tama-go/tools"
+)
+
+func TestToolsGetModifier(t *testing.T) {
+	expected := modifierFixture()
+	server := createMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/provision/tools/modifiers/modifier-123" {
+			t.Errorf("Expected modifier path, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tools.ModifierResponse{Data: expected})
+	})
+	defer server.Close()
+
+	client := modifierClient(server.URL)
+	modifier, err := client.Tools.GetModifier("modifier-123")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	validateModifierResponse(t, *modifier, expected)
+}
+
+func TestToolsCreateModifier(t *testing.T) {
+	expected := modifierFixture()
+	request := validCreateModifierRequest()
+
+	server := createMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/provision/tools/tool-456/modifiers" {
+			t.Errorf("Expected thought-tool modifier path, got %s", r.URL.Path)
+		}
+
+		modifier := decodeModifierEnvelope(t, r)
+		if len(modifier) != 5 {
+			t.Errorf("Expected 5 modifier fields, got %d: %v", len(modifier), modifier)
+		}
+		index, present := modifier["index"]
+		if !present {
+			t.Fatal("Expected index to be present in create payload")
+		}
+		if index != float64(0) {
+			t.Errorf("Expected index 0, got %v", index)
+		}
+		if modifier["target"] != request.Modifier.Target {
+			t.Errorf("Expected target %s, got %v", request.Modifier.Target, modifier["target"])
+		}
+		validateModifierSourcePayload(t, modifier["source"], request.Modifier.Source)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(tools.ModifierResponse{Data: expected})
+	})
+	defer server.Close()
+
+	client := modifierClient(server.URL)
+	modifier, err := client.Tools.CreateModifier("tool-456", request)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	validateModifierResponse(t, *modifier, expected)
+}
+
+func TestToolsUpdateModifierOmitsUnsetFields(t *testing.T) {
+	expected := modifierFixture()
+
+	server := createMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("Expected PATCH request, got %s", r.Method)
+		}
+		if r.URL.Path != "/provision/tools/modifiers/modifier-123" {
+			t.Errorf("Expected modifier path, got %s", r.URL.Path)
+		}
+
+		modifier := decodeModifierEnvelope(t, r)
+		if len(modifier) != 0 {
+			t.Errorf("Expected unset fields to be omitted, got %v", modifier)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tools.ModifierResponse{Data: expected})
+	})
+	defer server.Close()
+
+	client := modifierClient(server.URL)
+	modifier, err := client.Tools.UpdateModifier("modifier-123", tools.UpdateModifierRequest{})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	validateModifierResponse(t, *modifier, expected)
+}
+
+func TestToolsUpdateModifierSendsCompleteSource(t *testing.T) {
+	expected := modifierFixture()
+	source := tools.ModifierSource{
+		Type: tools.ModifierSourceTypeMetadata,
+		Path: tools.ModifierSourcePathOriginEntityIdentifier,
+	}
+
+	server := createMockServer(func(w http.ResponseWriter, r *http.Request) {
+		modifier := decodeModifierEnvelope(t, r)
+		if len(modifier) != 1 {
+			t.Errorf("Expected only source in update payload, got %v", modifier)
+		}
+		if _, present := modifier["index"]; present {
+			t.Error("Did not expect immutable index in update payload")
+		}
+		validateModifierSourcePayload(t, modifier["source"], source)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tools.ModifierResponse{Data: expected})
+	})
+	defer server.Close()
+
+	client := modifierClient(server.URL)
+	_, err := client.Tools.UpdateModifier("modifier-123", tools.UpdateModifierRequest{
+		Modifier: tools.UpdateModifierData{Source: &source},
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestToolsReplaceModifier(t *testing.T) {
+	expected := modifierFixture()
+	source := tools.ModifierSource{
+		Type: tools.ModifierSourceTypeMetadata,
+		Path: tools.ModifierSourcePathCurrentTimestamp,
+	}
+
+	server := createMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("Expected PUT request, got %s", r.Method)
+		}
+		if r.URL.Path != "/provision/tools/modifiers/modifier-123" {
+			t.Errorf("Expected modifier path, got %s", r.URL.Path)
+		}
+
+		modifier := decodeModifierEnvelope(t, r)
+		if _, present := modifier["index"]; present {
+			t.Error("Did not expect immutable index in replace payload")
+		}
+		validateModifierSourcePayload(t, modifier["source"], source)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tools.ModifierResponse{Data: expected})
+	})
+	defer server.Close()
+
+	client := modifierClient(server.URL)
+	modifier, err := client.Tools.ReplaceModifier("modifier-123", tools.UpdateModifierRequest{
+		Modifier: tools.UpdateModifierData{
+			OnMissingParent: tools.ModifierMissingPolicyError,
+			Source:          &source,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	validateModifierResponse(t, *modifier, expected)
+}
+
+func TestToolsDeleteModifierAcceptsInactiveResponse(t *testing.T) {
+	inactive := modifierFixture()
+	inactive.ProvisionState = "inactive"
+
+	server := createMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Expected DELETE request, got %s", r.Method)
+		}
+		if r.URL.Path != "/provision/tools/modifiers/modifier-123" {
+			t.Errorf("Expected modifier path, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(tools.ModifierResponse{Data: inactive})
+	})
+	defer server.Close()
+
+	client := modifierClient(server.URL)
+	if err := client.Tools.DeleteModifier("modifier-123"); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestToolsModifierValidationDoesNotMakeHTTPRequest(t *testing.T) {
+	var requestCount atomic.Int32
+	server := createMockServer(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer server.Close()
+
+	client := modifierClient(server.URL)
+	validCreate := validCreateModifierRequest()
+	validSource := validCreate.Modifier.Source
+
+	tests := []struct {
+		name        string
+		expectedErr string
+		call        func() error
+	}{
+		{
+			name:        "get empty modifier ID",
+			expectedErr: "modifier ID is required",
+			call: func() error {
+				_, err := client.Tools.GetModifier("")
+				return err
+			},
+		},
+		{
+			name:        "create empty thought tool ID",
+			expectedErr: "thought tool ID is required",
+			call: func() error {
+				_, err := client.Tools.CreateModifier("", validCreate)
+				return err
+			},
+		},
+		{
+			name:        "create negative index",
+			expectedErr: "modifier index must be non-negative",
+			call: func() error {
+				req := validCreate
+				req.Modifier.Index = -1
+				_, err := client.Tools.CreateModifier("tool-456", req)
+				return err
+			},
+		},
+		{
+			name:        "create missing target",
+			expectedErr: "modifier target is required",
+			call: func() error {
+				req := validCreate
+				req.Modifier.Target = ""
+				_, err := client.Tools.CreateModifier("tool-456", req)
+				return err
+			},
+		},
+		{
+			name:        "create missing parent policy",
+			expectedErr: "modifier on missing parent policy is required",
+			call: func() error {
+				req := validCreate
+				req.Modifier.OnMissingParent = ""
+				_, err := client.Tools.CreateModifier("tool-456", req)
+				return err
+			},
+		},
+		{
+			name:        "create missing source policy",
+			expectedErr: "modifier on missing source policy is required",
+			call: func() error {
+				req := validCreate
+				req.Modifier.OnMissingSource = ""
+				_, err := client.Tools.CreateModifier("tool-456", req)
+				return err
+			},
+		},
+		{
+			name:        "create missing source type",
+			expectedErr: "modifier source type is required",
+			call: func() error {
+				req := validCreate
+				req.Modifier.Source.Type = ""
+				_, err := client.Tools.CreateModifier("tool-456", req)
+				return err
+			},
+		},
+		{
+			name:        "create missing source path",
+			expectedErr: "modifier source path is required",
+			call: func() error {
+				req := validCreate
+				req.Modifier.Source.Path = ""
+				_, err := client.Tools.CreateModifier("tool-456", req)
+				return err
+			},
+		},
+		{
+			name:        "update empty modifier ID",
+			expectedErr: "modifier ID is required",
+			call: func() error {
+				_, err := client.Tools.UpdateModifier("", tools.UpdateModifierRequest{})
+				return err
+			},
+		},
+		{
+			name:        "update missing source type",
+			expectedErr: "modifier source type is required",
+			call: func() error {
+				source := validSource
+				source.Type = ""
+				_, err := client.Tools.UpdateModifier("modifier-123", tools.UpdateModifierRequest{
+					Modifier: tools.UpdateModifierData{Source: &source},
+				})
+				return err
+			},
+		},
+		{
+			name:        "update missing source path",
+			expectedErr: "modifier source path is required",
+			call: func() error {
+				source := validSource
+				source.Path = ""
+				_, err := client.Tools.UpdateModifier("modifier-123", tools.UpdateModifierRequest{
+					Modifier: tools.UpdateModifierData{Source: &source},
+				})
+				return err
+			},
+		},
+		{
+			name:        "replace empty modifier ID",
+			expectedErr: "modifier ID is required",
+			call: func() error {
+				_, err := client.Tools.ReplaceModifier("", tools.UpdateModifierRequest{})
+				return err
+			},
+		},
+		{
+			name:        "replace missing source path",
+			expectedErr: "modifier source path is required",
+			call: func() error {
+				source := validSource
+				source.Path = ""
+				_, err := client.Tools.ReplaceModifier("modifier-123", tools.UpdateModifierRequest{
+					Modifier: tools.UpdateModifierData{Source: &source},
+				})
+				return err
+			},
+		},
+		{
+			name:        "delete empty modifier ID",
+			expectedErr: "modifier ID is required",
+			call: func() error {
+				return client.Tools.DeleteModifier("")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.call()
+			if err == nil || err.Error() != test.expectedErr {
+				t.Errorf("Expected %q, got %v", test.expectedErr, err)
+			}
+		})
+	}
+
+	if count := requestCount.Load(); count != 0 {
+		t.Errorf("Expected no HTTP requests, got %d", count)
+	}
+}
+
+func TestToolsGetModifierNotFoundReturnsTypedError(t *testing.T) {
+	server := createMockServer(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{
+			"errors": map[string]string{"detail": "Not Found"},
+		})
+	})
+	defer server.Close()
+
+	client := modifierClient(server.URL)
+	_, err := client.Tools.GetModifier("modifier-123")
+	assertModifierAPIError(t, err, http.StatusNotFound, "detail", "Not Found")
+}
+
+func TestToolsCreateModifierPreservesNestedValidationError(t *testing.T) {
+	server := createMockServer(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		json.NewEncoder(w).Encode(map[string]any{
+			"errors": map[string]any{
+				"source": map[string][]string{"path": {"can't be blank"}},
+			},
+		})
+	})
+	defer server.Close()
+
+	client := modifierClient(server.URL)
+	_, err := client.Tools.CreateModifier("tool-456", validCreateModifierRequest())
+	assertModifierAPIError(t, err, http.StatusUnprocessableEntity, "source.path", "can't be blank")
+}
+
+func TestToolsModifierTransportErrorsIncludeOperation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	baseURL := server.URL
+	server.Close()
+
+	client := modifierClient(baseURL)
+	source := validCreateModifierRequest().Modifier.Source
+	tests := []struct {
+		name      string
+		operation string
+		call      func() error
+	}{
+		{
+			name:      "get",
+			operation: "failed to get modifier",
+			call: func() error {
+				_, err := client.Tools.GetModifier("modifier-123")
+				return err
+			},
+		},
+		{
+			name:      "create",
+			operation: "failed to create modifier",
+			call: func() error {
+				_, err := client.Tools.CreateModifier("tool-456", validCreateModifierRequest())
+				return err
+			},
+		},
+		{
+			name:      "update",
+			operation: "failed to update modifier",
+			call: func() error {
+				_, err := client.Tools.UpdateModifier("modifier-123", tools.UpdateModifierRequest{
+					Modifier: tools.UpdateModifierData{Source: &source},
+				})
+				return err
+			},
+		},
+		{
+			name:      "delete",
+			operation: "failed to delete modifier",
+			call: func() error {
+				return client.Tools.DeleteModifier("modifier-123")
+			},
+		},
+		{
+			name:      "replace",
+			operation: "failed to replace modifier",
+			call: func() error {
+				_, err := client.Tools.ReplaceModifier("modifier-123", tools.UpdateModifierRequest{
+					Modifier: tools.UpdateModifierData{Source: &source},
+				})
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.call()
+			if err == nil || !strings.Contains(err.Error(), test.operation) {
+				t.Errorf("Expected error containing %q, got %v", test.operation, err)
+			}
+		})
+	}
+}
+
+func modifierClient(baseURL string) *tama.Client {
+	return tama.NewClient(tama.Config{
+		BaseURL: baseURL,
+		APIKey:  "test-key",
+		Timeout: 10 * time.Second,
+	})
+}
+
+func modifierFixture() tools.Modifier {
+	return tools.Modifier{
+		ID:              "modifier-123",
+		Index:           0,
+		Target:          "/body/search/scope/user_id",
+		OnMissingParent: tools.ModifierMissingPolicySkip,
+		OnMissingSource: tools.ModifierMissingPolicyError,
+		Source: tools.ModifierSource{
+			Type: tools.ModifierSourceTypeMetadata,
+			Path: tools.ModifierSourcePathActorIdentifier,
+		},
+		ThoughtToolID:  "tool-456",
+		ProvisionState: "active",
+	}
+}
+
+func validCreateModifierRequest() tools.CreateModifierRequest {
+	modifier := modifierFixture()
+
+	return tools.CreateModifierRequest{
+		Modifier: tools.ModifierRequestData{
+			Index:           modifier.Index,
+			Target:          modifier.Target,
+			OnMissingParent: modifier.OnMissingParent,
+			OnMissingSource: modifier.OnMissingSource,
+			Source:          modifier.Source,
+		},
+	}
+}
+
+func decodeModifierEnvelope(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+
+	var envelope map[string]map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		t.Fatalf("Failed to decode modifier request: %v", err)
+	}
+
+	modifier, present := envelope["modifier"]
+	if !present {
+		t.Fatal("Expected modifier envelope")
+	}
+	if len(envelope) != 1 {
+		t.Errorf("Expected only modifier envelope, got %v", envelope)
+	}
+
+	return modifier
+}
+
+func validateModifierSourcePayload(t *testing.T, actual any, expected tools.ModifierSource) {
+	t.Helper()
+
+	source, ok := actual.(map[string]any)
+	if !ok {
+		t.Fatalf("Expected source object, got %T", actual)
+	}
+	if len(source) != 2 {
+		t.Errorf("Expected complete source with 2 fields, got %v", source)
+	}
+	if source["type"] != expected.Type {
+		t.Errorf("Expected source type %s, got %v", expected.Type, source["type"])
+	}
+	if source["path"] != expected.Path {
+		t.Errorf("Expected source path %s, got %v", expected.Path, source["path"])
+	}
+}
+
+func validateModifierResponse(t *testing.T, actual, expected tools.Modifier) {
+	t.Helper()
+
+	if actual != expected {
+		t.Errorf("Expected modifier %+v, got %+v", expected, actual)
+	}
+}
+
+func assertModifierAPIError(
+	t *testing.T,
+	err error,
+	statusCode int,
+	field string,
+	message string,
+) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("Expected API error, got nil")
+	}
+
+	var apiErr *tools.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Expected *tools.Error, got %T", err)
+	}
+	if apiErr.StatusCode != statusCode {
+		t.Errorf("Expected status code %d, got %d", statusCode, apiErr.StatusCode)
+	}
+	if len(apiErr.Errors[field]) != 1 || apiErr.Errors[field][0] != message {
+		t.Errorf("Expected %s error %q, got %v", field, message, apiErr.Errors)
+	}
+}

--- a/tools/modifier_test.go
+++ b/tools/modifier_test.go
@@ -29,7 +29,7 @@ func TestToolsGetModifier(t *testing.T) {
 	})
 	defer server.Close()
 
-	client := modifierClient(server.URL)
+	client := modifierClient(t, server.URL)
 	modifier, err := client.Tools.GetModifier("modifier-123")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -72,7 +72,7 @@ func TestToolsCreateModifier(t *testing.T) {
 	})
 	defer server.Close()
 
-	client := modifierClient(server.URL)
+	client := modifierClient(t, server.URL)
 	modifier, err := client.Tools.CreateModifier("tool-456", request)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -102,7 +102,7 @@ func TestToolsUpdateModifierOmitsUnsetFields(t *testing.T) {
 	})
 	defer server.Close()
 
-	client := modifierClient(server.URL)
+	client := modifierClient(t, server.URL)
 	modifier, err := client.Tools.UpdateModifier("modifier-123", tools.UpdateModifierRequest{})
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -133,7 +133,7 @@ func TestToolsUpdateModifierSendsCompleteSource(t *testing.T) {
 	})
 	defer server.Close()
 
-	client := modifierClient(server.URL)
+	client := modifierClient(t, server.URL)
 	_, err := client.Tools.UpdateModifier("modifier-123", tools.UpdateModifierRequest{
 		Modifier: tools.UpdateModifierData{Source: &source},
 	})
@@ -168,7 +168,7 @@ func TestToolsReplaceModifier(t *testing.T) {
 	})
 	defer server.Close()
 
-	client := modifierClient(server.URL)
+	client := modifierClient(t, server.URL)
 	modifier, err := client.Tools.ReplaceModifier("modifier-123", tools.UpdateModifierRequest{
 		Modifier: tools.UpdateModifierData{
 			OnMissingParent: tools.ModifierMissingPolicyError,
@@ -199,7 +199,7 @@ func TestToolsDeleteModifierAcceptsInactiveResponse(t *testing.T) {
 	})
 	defer server.Close()
 
-	client := modifierClient(server.URL)
+	client := modifierClient(t, server.URL)
 	if err := client.Tools.DeleteModifier("modifier-123"); err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -213,7 +213,7 @@ func TestToolsModifierValidationDoesNotMakeHTTPRequest(t *testing.T) {
 	})
 	defer server.Close()
 
-	client := modifierClient(server.URL)
+	client := modifierClient(t, server.URL)
 	validCreate := validCreateModifierRequest()
 	validSource := validCreate.Modifier.Source
 
@@ -383,7 +383,7 @@ func TestToolsGetModifierNotFoundReturnsTypedError(t *testing.T) {
 	})
 	defer server.Close()
 
-	client := modifierClient(server.URL)
+	client := modifierClient(t, server.URL)
 	_, err := client.Tools.GetModifier("modifier-123")
 	assertModifierAPIError(t, err, http.StatusNotFound, "detail", "Not Found")
 }
@@ -400,7 +400,7 @@ func TestToolsCreateModifierPreservesNestedValidationError(t *testing.T) {
 	})
 	defer server.Close()
 
-	client := modifierClient(server.URL)
+	client := modifierClient(t, server.URL)
 	_, err := client.Tools.CreateModifier("tool-456", validCreateModifierRequest())
 	assertModifierAPIError(t, err, http.StatusUnprocessableEntity, "source.path", "can't be blank")
 }
@@ -410,7 +410,7 @@ func TestToolsModifierTransportErrorsIncludeOperation(t *testing.T) {
 	baseURL := server.URL
 	server.Close()
 
-	client := modifierClient(baseURL)
+	client := modifierClient(t, baseURL)
 	source := validCreateModifierRequest().Modifier.Source
 	tests := []struct {
 		name      string
@@ -472,12 +472,19 @@ func TestToolsModifierTransportErrorsIncludeOperation(t *testing.T) {
 	}
 }
 
-func modifierClient(baseURL string) *tama.Client {
-	return tama.NewClient(tama.Config{
+func modifierClient(t *testing.T, baseURL string) *tama.Client {
+	t.Helper()
+
+	client, err := tama.NewClient(tama.Config{
 		BaseURL: baseURL,
 		APIKey:  "test-key",
 		Timeout: 10 * time.Second,
 	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	return client
 }
 
 func modifierFixture() tools.Modifier {

--- a/wip/trusted-tool-modifier-api.md
+++ b/wip/trusted-tool-modifier-api.md
@@ -1,0 +1,444 @@
+# Trusted Tool Modifier API Client Support
+
+## Status
+
+The `tama-go` client described here is implemented in this checkout. The
+Terraform resource remains a follow-up and the client has not been released.
+
+The server-side API that introduces `Tama.Tools.Modifier` is merged into Tama's
+`develop` branch. Confirm that it is deployed in the target environment before
+using the client from `terraform-provider-tama`.
+
+## Goal
+
+Add typed support for the trusted thought-tool modifier provision API to the
+existing `tools.Service`. The resulting `tama-go` release must expose the CRUD
+operations and error information needed to implement a
+`tama_thought_tool_modifier` resource in `terraform-provider-tama`.
+
+The client is only a provisioning transport. Modifier execution, trusted
+metadata resolution, JSON Schema compatibility, lifecycle transitions, and
+conflict enforcement remain Tama server responsibilities.
+
+## Motivation
+
+Trusted tool modifiers let Tama populate selected action request arguments from
+authoritative runtime metadata instead of model-generated text. The first
+consumer needs to provision an actor identifier into a nested request field:
+
+```text
+/body/search/scope/user_id
+```
+
+Terraform needs a stable resource for this configuration. The provider already
+uses `tama-go` for thought-tool inputs, outputs, initializers, and options, so
+the modifier resource should use the same boundary rather than constructing
+HTTP requests inside the provider.
+
+## Authoritative Tama API contract
+
+All endpoints use the authenticated `/provision` API pipeline.
+
+| Operation | Method and path | Success | Notes |
+| --- | --- | --- | --- |
+| Create or reactivate | `POST /provision/tools/:thought_tool_id/modifiers` | `201` | Creates an inactive record and activates it. An exact inactive configuration is reactivated with the same ID. |
+| Show | `GET /provision/tools/modifiers/:id` | `200` | Only active modifiers are visible. Invalid, unknown, and inactive IDs return `404`. |
+| Update | `PATCH /provision/tools/modifiers/:id` | `200` | Can update active or inactive records. `index` is immutable. Active updates revalidate compatibility and conflicts. |
+| Replace fields | `PUT /provision/tools/modifiers/:id` | `200` | Phoenix routes PUT to the same update action as PATCH. It accepts the same mutable fields and cannot replace `index`. |
+| Deactivate | `DELETE /provision/tools/modifiers/:id` | `200` | Deactivates the active record and returns it with `provision_state = "inactive"`. A later show returns `404`. |
+
+There is no list endpoint. Do not add `ListModifier` unless Tama adds that
+route. The generated Phoenix resource routes do include PUT, matching adjacent
+Tools resources and their `Replace*` client methods.
+
+### Authorization
+
+A Terraform credential that manages the complete resource lifecycle needs
+read and manage access. Any one of the broad scopes below covers all actions:
+
+```text
+provision.all
+provision.tools.all
+```
+
+The narrow scopes are:
+
+```text
+provision.tools.modifier.read
+provision.tools.modifier.manage
+```
+
+`read` authorizes show. `manage` authorizes create, update, and delete; it does
+not authorize show by itself. A narrowly scoped provider credential therefore
+needs both capabilities.
+
+### Request shape
+
+Create wraps the complete configuration under `modifier`:
+
+```json
+{
+  "modifier": {
+    "index": 0,
+    "target": "/body/search/scope/user_id",
+    "on_missing_parent": "skip",
+    "on_missing_source": "error",
+    "source": {
+      "type": "metadata",
+      "path": "actor_identifier"
+    }
+  }
+}
+```
+
+The create fields are all required. `provision_state`, `id`, and
+`thought_tool_id` are server-owned and must not be sent in the body.
+
+Update uses the same envelope with only mutable fields:
+
+```json
+{
+  "modifier": {
+    "target": "/body/search/scope/user_id",
+    "on_missing_parent": "skip",
+    "on_missing_source": "error",
+    "source": {
+      "type": "metadata",
+      "path": "actor_identifier"
+    }
+  }
+}
+```
+
+The client update type should omit `index`. Tama rejects changing it, and the
+Terraform resource must model an index change as replacement.
+
+### Response shape
+
+Every successful endpoint returns the resource in a `data` envelope:
+
+```json
+{
+  "data": {
+    "id": "019c...",
+    "index": 0,
+    "target": "/body/search/scope/user_id",
+    "on_missing_parent": "skip",
+    "on_missing_source": "error",
+    "source": {
+      "type": "metadata",
+      "path": "actor_identifier"
+    },
+    "thought_tool_id": "019c...",
+    "provision_state": "active"
+  }
+}
+```
+
+The delete response has the same shape with `provision_state` set to
+`inactive`. The client delete method discards this body, consistent with the
+existing Tools CRUD methods; Terraform only needs to know whether deactivation
+succeeded.
+
+### Allowed values and server validation
+
+Version 1 allows these values:
+
+```text
+on_missing_parent: error | skip
+on_missing_source: error | skip
+source.type: metadata
+source.path: actor_identifier | origin_entity_identifier | current_timestamp
+```
+
+The server also enforces:
+
+- `index` is non-negative, immutable after creation, and unique among active
+  modifiers owned by one thought tool;
+- `target` is an RFC 6901 JSON Pointer encoded in at most 512 bytes;
+- the decoded target contains 2 through 16 non-empty tokens;
+- the first token is `body`, `path`, or `query`;
+- traversal is limited to ordinary object properties in version 1;
+- array, `oneOf`, `anyOf`, `allOf`, and dynamic `additionalProperties`
+  traversal is unsupported;
+- the target must resolve in at least one complete callable schema owned by the
+  thought tool; and
+- active targets cannot be equal or have an ancestor/descendant relationship.
+
+Do not duplicate callable-schema resolution or active conflict detection in
+`tama-go`. Those checks depend on current server state and imported action
+specifications. The client may reject structurally empty required fields and
+negative indexes, but Tama remains authoritative and returns field errors for
+invalid targets or configurations.
+
+## Proposed `tama-go` public API
+
+Add `tools/modifier.go`. The resource belongs in the existing `tools` package,
+not `motor`; `motor.Modifier` is a different action-level schema modifier.
+
+Use string fields, matching adjacent `tama-go` resources, and export constants
+to prevent consumers from repeating wire literals:
+
+```go
+const (
+    ModifierMissingPolicyError = "error"
+    ModifierMissingPolicySkip  = "skip"
+
+    ModifierSourceTypeMetadata = "metadata"
+
+    ModifierSourcePathActorIdentifier        = "actor_identifier"
+    ModifierSourcePathOriginEntityIdentifier = "origin_entity_identifier"
+    ModifierSourcePathCurrentTimestamp       = "current_timestamp"
+)
+
+type ModifierSource struct {
+    Type string `json:"type"`
+    Path string `json:"path"`
+}
+
+type Modifier struct {
+    ID              string         `json:"id,omitempty"`
+    Index           int            `json:"index"`
+    Target          string         `json:"target"`
+    OnMissingParent string         `json:"on_missing_parent"`
+    OnMissingSource string         `json:"on_missing_source"`
+    Source          ModifierSource `json:"source"`
+    ThoughtToolID   string         `json:"thought_tool_id,omitempty"`
+    ProvisionState  string         `json:"provision_state"`
+}
+
+type ModifierResponse struct {
+    Data Modifier `json:"data"`
+}
+
+type CreateModifierRequest struct {
+    Modifier ModifierRequestData `json:"modifier"`
+}
+
+type ModifierRequestData struct {
+    Index           int            `json:"index"`
+    Target          string         `json:"target"`
+    OnMissingParent string         `json:"on_missing_parent"`
+    OnMissingSource string         `json:"on_missing_source"`
+    Source          ModifierSource `json:"source"`
+}
+
+type UpdateModifierRequest struct {
+    Modifier UpdateModifierData `json:"modifier"`
+}
+
+type UpdateModifierData struct {
+    Target          string          `json:"target,omitempty"`
+    OnMissingParent string          `json:"on_missing_parent,omitempty"`
+    OnMissingSource string          `json:"on_missing_source,omitempty"`
+    Source          *ModifierSource `json:"source,omitempty"`
+}
+```
+
+`Source` is a pointer only on update so an omitted source is distinguishable
+from a supplied source. If it is supplied, send both `type` and `path`.
+
+Expose these methods on `*tools.Service`, which automatically makes them
+available through `client.Tools`:
+
+```go
+func (s *Service) GetModifier(id string) (*Modifier, error)
+
+func (s *Service) CreateModifier(
+    thoughtToolID string,
+    req CreateModifierRequest,
+) (*Modifier, error)
+
+func (s *Service) UpdateModifier(
+    id string,
+    req UpdateModifierRequest,
+) (*Modifier, error)
+
+func (s *Service) ReplaceModifier(
+    id string,
+    req UpdateModifierRequest,
+) (*Modifier, error)
+
+func (s *Service) DeleteModifier(id string) error
+```
+
+Method behavior should follow `tools/input.go`, `tools/output.go`, and
+`tools/initializer.go`:
+
+1. reject an empty resource ID before making an HTTP request;
+2. reject an empty thought-tool ID on create;
+3. validate the complete create payload's required fields and non-negative
+   index;
+4. preserve partial PATCH and PUT semantics, validating both nested source
+   fields only when `source` is supplied;
+5. use `SetBody`, `SetResult`, and the shared Resty client;
+6. call `handleAPIError` for every non-success response;
+7. wrap transport failures with operation-specific context; and
+8. return the decoded `data` value for get, create, and update.
+
+An update or replacement with no supplied fields is sent as
+`{"modifier": {}}`, matching the existing Tools convention and Tama's no-op
+update behavior. `ReplaceModifier` shares `UpdateModifierRequest` because PUT
+routes to the same server action and still cannot change `index`.
+
+Do not add a second service constructor or a new root client field. The current
+`ToolsService` embeds `*tools.Service`, so methods added to that service are
+already promoted to `client.Tools`.
+
+### Error contract needed by Terraform
+
+The existing `tools.Error` must remain the returned error for parsed API
+failures. In particular, the provider needs to detect an inactive or externally
+deleted modifier during refresh:
+
+```go
+var apiErr *tools.Error
+if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+    // Remove the Terraform resource from state.
+}
+```
+
+Validation failures should retain Tama's flattened field keys and messages,
+for example `target`, `index`, `source.type`, or `source.path`. Do not replace a
+server `422` with an untyped formatted string.
+
+## `tama-go` test plan
+
+Add `tools/modifier_test.go` using the existing `httptest` helpers. Cover:
+
+- get uses `GET /provision/tools/modifiers/:id` and decodes every response
+  field, including the nested source;
+- create uses `POST /provision/tools/:thought_tool_id/modifiers`, preserves
+  `index: 0`, sends the complete envelope, accepts `201`, and decodes the active
+  resource; inspect the raw JSON object so omission cannot be mistaken for a
+  decoded zero value;
+- update uses `PATCH /provision/tools/modifiers/:id`, omits unset fields, and
+  sends a complete nested source when present; inspect the raw JSON object to
+  prove absent fields and the immutable index are not serialized;
+- replace uses `PUT /provision/tools/modifiers/:id`, shares the mutable update
+  request, and cannot serialize the immutable index;
+- delete uses `DELETE /provision/tools/modifiers/:id` and treats the `200`
+  inactive response as success;
+- empty IDs, empty thought-tool IDs, negative indexes, missing targets,
+  missing policies, and incomplete sources fail locally without an HTTP call;
+- Tama's `{"errors":{"detail":"Not Found"}}` response becomes `*tools.Error`
+  with `StatusCode == 404`;
+- a real nested changeset shape such as
+  `{"errors":{"source":{"path":["can't be blank"]}}}` preserves the
+  `source.path` field and its messages; and
+- transport errors retain get/create/update/replace/delete operation context.
+
+Run:
+
+```bash
+go test ./tools
+make check
+go build ./...
+go test -race ./...
+go mod tidy
+git diff --check
+```
+
+The final diff after `go mod tidy` must not contain unintended module changes.
+A live integration test is optional and must use a disposable thought tool
+whose action schema contains the chosen target; unit tests must not depend on
+deployed API state.
+
+Update the Tools service comments, `docs/tools.md`, the documentation index, and
+the root README so the public client surface includes modifiers. Remove stale
+examples that use nonexistent nested services, contexts, or list endpoints.
+Document that Tools `Replace*` methods route PUT to the same update actions as
+PATCH and therefore accept only their mutable request fields.
+
+## Terraform provider handoff
+
+After a released `tama-go` version contains the client methods, implement a
+`tama_thought_tool_modifier` resource in `terraform-provider-tama`. Do not use
+the existing `tama_motor_modifier` resource as the API model; it represents a
+different resource.
+
+The expected Terraform model is:
+
+| Attribute | Mode | Lifecycle |
+| --- | --- | --- |
+| `id` | computed | Server-generated modifier ID. |
+| `thought_tool_id` | required | `RequiresReplace`; ownership cannot move. |
+| `index` | required integer | Non-negative and `RequiresReplace`; Tama makes it immutable. |
+| `target` | required string | Mutable; server validates pointer syntax and callable compatibility. |
+| `on_missing_parent` | required string | Mutable; validate `error` or `skip`. |
+| `on_missing_source` | required string | Mutable; validate `error` or `skip`. |
+| `source` | required single nested object | Mutable; contains required `type` and `path`. |
+| `provision_state` | computed | Expected to be `active` while managed. |
+
+The nested source validators should allow only `metadata` for `type` and the
+three version 1 metadata paths. If the provider validates the target length, it
+must count UTF-8 bytes rather than characters; otherwise leave the 512-byte
+check to Tama to avoid a mismatched rule.
+
+Provider lifecycle requirements:
+
+- Create maps the Terraform plan to `tools.CreateModifierRequest` and accepts
+  the ID returned by create or exact reactivation.
+- Read maps all server fields back into state. A typed `404` must call
+  `resp.State.RemoveResource(ctx)` instead of producing a permanent diagnostic.
+- Update sends `target`, both missing-value policies, and the complete source.
+  It must not send `index`.
+- Delete calls `DeleteModifier`; Terraform then removes the resource from
+  state. Deactivation, rather than physical deletion, is the intended server
+  behavior.
+- Import accepts the modifier ID and reads the active resource. Importing an
+  inactive ID must fail as not found.
+
+Register the resource in `tama/provider.go`, add resource and acceptance tests,
+and generate documentation and examples following the adjacent thought-tool
+resources. Acceptance coverage should include create, update, import, delete,
+exact reactivation, a negative index validation, an invalid target API error,
+and refresh after external deactivation.
+
+During local provider development, a temporary Go module replacement may point
+`github.com/upmaru/tama-go` at `../tama-go`. Remove that replacement before
+release. The provider's pinned `tama-go` version must ultimately be advanced to
+the released version containing this API.
+
+## Sequencing
+
+1. Merge and deploy the Tama modifier API where integration or acceptance tests
+   will run.
+2. Implement and validate `tools/modifier.go` and its unit tests in `tama-go`.
+3. Update client documentation and examples.
+4. Release `tama-go`; do not assume a version number before checking registry
+   and repository state.
+5. Update `terraform-provider-tama` to the released client version.
+6. Implement, register, document, and acceptance-test
+   `tama_thought_tool_modifier`.
+7. Release the provider only after its generated documentation and full test
+   gates pass.
+
+## Non-goals
+
+This client phase does not:
+
+- implement modifier execution or trusted metadata resolution;
+- inspect action schemas locally;
+- add a list endpoint that Tama does not expose;
+- implement the Terraform resource in `tama-go`;
+- deploy the modifier to any Memovee graph; or
+- remove prompt-based identifier instructions before the modifier is
+  provisioned in the target environment.
+
+## Completion criteria
+
+The `tama-go` phase is complete only when:
+
+- all request, response, resource, source, and constant types are public;
+- get, create, update, replace, and delete call the exact Tama routes;
+- zero is preserved as a valid required create index;
+- update cannot accidentally request an index change;
+- nested source values round-trip without a generic `map[string]any`;
+- `404` and `422` responses remain typed `*tools.Error` values;
+- modifier unit tests cover methods, payloads, validation, and API errors;
+- the full `tama-go` quality gate passes; and
+- public Tools documentation reflects the implemented surface.
+
+Provider work may begin against a local client checkout after these contracts
+pass, but a provider release must depend on a released `tama-go` version.


### PR DESCRIPTION
## Description

Adds typed `tama-go` support for provisioning trusted thought-tool modifiers through `client.Tools`.

Trusted modifiers reserve selected action-request fields for values resolved from authoritative Tama runtime metadata instead of model-generated arguments. This client remains a provisioning transport: target compatibility, conflict detection, lifecycle transitions, and trusted metadata resolution stay server-side.

The implementation follows the adjacent Tools resource conventions and exposes:

- `GetModifier`
- `CreateModifier`
- `UpdateModifier`
- `ReplaceModifier`
- `DeleteModifier`

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test improvement
- [ ] CI/CD improvement
- [ ] Dependency update

## Related Issues

- Depends on upmaru/tama#99, which is merged into Tama's `develop` branch.
- Terraform provider support remains a follow-up after this client is released.

## Changes Made

- [x] Added public modifier, source, request, response, and wire-value constant types.
- [x] Added GET, POST, PATCH, PUT, and DELETE support through the existing embedded `tools.Service`.
- [x] Preserved `index: 0` on create and excluded immutable `index` from update/replace requests.
- [x] Added local structural validation for IDs, required create fields, non-negative indexes, and supplied nested sources.
- [x] Preserved Tama `404` and nested `422` responses as typed `*tools.Error` values.
- [x] Added raw-wire tests for envelopes, zero-value serialization, omitted PATCH fields, and complete nested sources.
- [x] Added validation-without-HTTP, API-error, lifecycle response, and transport-context coverage.
- [x] Reworked the stale Tools documentation and updated the README, documentation index, and service inventory.
- [x] Updated the implementation document to reflect the merged server contract and verified route surface.

## API Notes

- There is no modifier list endpoint.
- Phoenix generates both PATCH and PUT routes for the update action. `ReplaceModifier` therefore shares `UpdateModifierRequest` and cannot change `index`.
- Get only returns active modifiers. Invalid, unknown, or inactive IDs produce a typed `404`.
- Delete deactivates the resource; the client intentionally discards the returned inactive representation.
- Create can reactivate an exact inactive configuration and retain its ID.

## Breaking Changes

None. The new methods are promoted through the existing `Client.Tools` service; no new root service or constructor is introduced.

## Testing

- [x] All existing tests pass.
- [x] New tests cover the public modifier operations.
- [x] Tests cover structural validation and edge cases.
- [x] Error handling is covered with Tama's real response shapes.
- [x] Transport failures retain operation-specific context.
- [ ] Live deployed integration test.

Validated locally with:

```text
make check
go build ./...
go test -race ./...
go mod tidy
git diff --check
```

The focused merged Tama server contract suite also passes:

```text
mix test test/tama_web/controllers/provision/tools/modifier_controller_test.exs
4 tests, 0 failures
```

No live integration test was run because deployment availability was not confirmed.

## Documentation

- [x] Exported types, constants, and methods have Godoc comments.
- [x] `README.md` includes the Tools package and modifier endpoints.
- [x] `docs/README.md` links the Tools service.
- [x] `docs/tools.md` reflects the actual `Client.Tools` surface and route semantics.
- [x] `wip/trusted-tool-modifier-api.md` reflects the implemented client and validation gates.

## Code Quality

- [x] Code follows existing Tools service patterns.
- [x] No lint issues were introduced.
- [x] Code is formatted with `gofmt`.
- [x] `go mod tidy` produces no dependency changes.
- [x] Full tests pass with the race detector.

## Example

```go
modifier, err := client.Tools.CreateModifier("tool-123", tools.CreateModifierRequest{
    Modifier: tools.ModifierRequestData{
        Index:           0,
        Target:          "/body/search/scope/user_id",
        OnMissingParent: tools.ModifierMissingPolicySkip,
        OnMissingSource: tools.ModifierMissingPolicyError,
        Source: tools.ModifierSource{
            Type: tools.ModifierSourceTypeMetadata,
            Path: tools.ModifierSourcePathActorIdentifier,
        },
    },
})
```

## Performance Impact

- [x] No meaningful performance impact.

The change adds only typed request construction, response decoding, and lightweight local structural validation.

## Security Considerations

- [x] Server authorization and validation remain authoritative.

The client does not resolve or execute trusted metadata. It only transports modifier configuration through the authenticated provision API and preserves typed server errors for callers.

## Reviewer Notes

Please pay particular attention to:

- [x] Public API and naming alongside the existing `motor.Modifier` type.
- [x] Immutable index handling across PATCH and PUT.
- [x] Raw-wire serialization tests, especially required zero index handling.
- [x] Typed `404` and nested `source.path` error preservation.
- [x] Documentation accuracy around PUT, deactivation, and reactivation.
